### PR TITLE
[WIP] Don't allow superfluous prefixes/suffixes

### DIFF
--- a/not-yet/trait/name-trait
+++ b/not-yet/trait/name-trait
@@ -1,0 +1,16 @@
+---DESCRIPTION---
+Forbid Trait suffix
+---FILENAME---
+FooTrait.php
+---CONTENTS---
+<?php
+
+namespace Vendor;
+
+trait FooTrait
+{
+}
+
+---MESSAGES---
+5:1 Libero.Classes.SuperfluousTraitNaming.SuperfluousSuffix
+---

--- a/src/Libero/ruleset.xml
+++ b/src/Libero/ruleset.xml
@@ -10,6 +10,9 @@
         <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
         <properties>
             <property name="psr12Compatible" value="true"/>

--- a/tests/cases/classes/name-abstract
+++ b/tests/cases/classes/name-abstract
@@ -1,0 +1,16 @@
+---DESCRIPTION---
+Forbid Abstract prefix
+---FILENAME---
+AbstractFoo.php
+---CONTENTS---
+<?php
+
+namespace Vendor;
+
+abstract class AbstractFoo
+{
+}
+
+---MESSAGES---
+5:10 SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix
+---

--- a/tests/cases/classes/name-exception
+++ b/tests/cases/classes/name-exception
@@ -1,0 +1,18 @@
+---DESCRIPTION---
+Forbid Exception suffix
+---FILENAME---
+FooException.php
+---CONTENTS---
+<?php
+
+namespace Vendor;
+
+use Exception;
+
+class FooException extends Exception
+{
+}
+
+---MESSAGES---
+7:1 SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix
+---

--- a/tests/cases/interfaces/name-interface
+++ b/tests/cases/interfaces/name-interface
@@ -1,0 +1,16 @@
+---DESCRIPTION---
+Forbid Interface suffix
+---FILENAME---
+FooInterface.php
+---CONTENTS---
+<?php
+
+namespace Vendor;
+
+interface FooInterface
+{
+}
+
+---MESSAGES---
+5:1 SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix
+---


### PR DESCRIPTION
Also opened https://github.com/slevomat/coding-standard/pull/491 to apply the same to the `Trait` suffix.