### PR TITLE
Use statements must be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
-        "slevomat/coding-standard": "^4.6.1",
+        "slevomat/coding-standard": "^4.8",
         "squizlabs/php_codesniffer": "^3.3.2"
     },
     "require-dev": {

--- a/src/Libero/ruleset.xml
+++ b/src/Libero/ruleset.xml
@@ -15,8 +15,15 @@
             <property name="psr12Compatible" value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFallbackGlobalConstants" value="false"/>
+            <property name="allowFallbackGlobalFunctions" value="false"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>

--- a/tests/RulesetTests.php
+++ b/tests/RulesetTests.php
@@ -21,6 +21,7 @@ use function Functional\select_keys;
 use function implode;
 use function ini_get;
 use function mb_convert_encoding;
+use function mb_detect_encoding;
 use function preg_match_all;
 use function preg_replace;
 use function sort;

--- a/tests/cases/php/global-fallbacks
+++ b/tests/cases/php/global-fallbacks
@@ -1,15 +1,13 @@
 ---DESCRIPTION---
-Use declarations must go after the namespace declaration
+No global fallbacks
 ---CONTENTS---
 <?php
 
 declare(strict_types=1);
 
-use Foo;
-
 namespace Vendor;
 
-new Foo();
+date(DATE_ATOM);
 
 ---FIXED---
 <?php
@@ -18,6 +16,9 @@ declare(strict_types=1);
 
 namespace Vendor;
 
-new Foo();
+use function date;
+use const DATE_ATOM;
+
+date(DATE_ATOM);
 
 ---

--- a/tests/cases/php/use-fully-qualified
+++ b/tests/cases/php/use-fully-qualified
@@ -1,0 +1,32 @@
+---DESCRIPTION---
+Use statements must be used
+---CONTENTS---
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor;
+
+new \Foo(\bar(\BAZ));
+new \Qux\Quux(\Qux\quuz(\Qux\CORGE));
+new \Vendor\Grault(\Vendor\garply(\Vendor\WALDO));
+
+---FIXED---
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor;
+
+use Foo;
+use Qux\Quux;
+use function bar;
+use function Qux\quuz;
+use const BAZ;
+use const Qux\CORGE;
+
+new Foo(bar(BAZ));
+new Quux(quuz(CORGE));
+new Grault(garply(WALDO));
+
+---

--- a/tests/cases/php/use-useless
+++ b/tests/cases/php/use-useless
@@ -1,0 +1,25 @@
+---DESCRIPTION---
+Use statements must not be from the same namespace
+---CONTENTS---
+<?php
+
+declare(strict_types=1);
+
+namespace Foo;
+
+use Foo\Bar;
+use function Foo\baz;
+use const Foo\QUX;
+
+new Bar(baz(QUX));
+
+---FIXED---
+<?php
+
+declare(strict_types=1);
+
+namespace Foo;
+
+new Bar(baz(QUX));
+
+---

--- a/tests/cases/whitespace/use-namespace
+++ b/tests/cases/whitespace/use-namespace
@@ -5,19 +5,12 @@ Use declarations must go after the namespace declaration
 
 declare(strict_types=1);
 
-use Foo;
+use Foo\Bar;
 
 namespace Vendor;
 
-new Foo();
+new Bar();
 
----FIXED---
-<?php
-
-declare(strict_types=1);
-
-namespace Vendor;
-
-new Foo();
-
+---MESSAGES---
+5:1 PSR2.Namespaces.UseDeclaration.UseBeforeNamespace
 ---


### PR DESCRIPTION
Requires `use` statements (so no FCQN and no global fallbacks).