### PR TITLE
Allow standards installer 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "^7.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4 || ^0.5",
         "slevomat/coding-standard": "^4.8",
         "squizlabs/php_codesniffer": "^3.3.2"
     },

--- a/tests/cases/trait/one-per-file
+++ b/tests/cases/trait/one-per-file
@@ -19,4 +19,5 @@ trait Bar
 
 ---MESSAGES---
 11:1 PSR1.Classes.ClassDeclaration.MultipleClasses
+11:1 Squiz.Classes.ClassFileName.NoMatch
 ---


### PR DESCRIPTION
Hit a few Composer problems (https://github.com/Dealerdirect/phpcodesniffer-composer-installer/issues/49), this should fix it.