### PR TITLE
Allow ignoring messages in tests to avoid version compatibility problems

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
         "slevomat/coding-standard": "^4.8",
-        "squizlabs/php_codesniffer": "^3.3.2"
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "require-dev": {
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
         "slevomat/coding-standard": "^4.8",
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3.2"
     },
     "require-dev": {
         "ext-mbstring": "*",

--- a/tests/RulesetTests.php
+++ b/tests/RulesetTests.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Runner;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use function array_combine;
+use function array_diff;
 use function array_filter;
 use function array_map;
 use function explode;
@@ -53,11 +54,12 @@ final class RulesetTests extends TestCase
         string $contents,
         string $fixed,
         array $messages,
+        array $ignoreMessages,
         ?string $description,
         ?string $fixedEncoding
     ) : void {
         $file = $this->createFile($filename, $contents);
-        $actual = flatten($this->getMessages($file));
+        $actual = array_diff(flatten($this->getMessages($file)), $ignoreMessages);
 
         sort($actual);
         sort($messages);
@@ -82,6 +84,10 @@ final class RulesetTests extends TestCase
 
             if (isset($parts['messages'])) {
                 $parts['messages'] = array_filter(explode("\n", $parts['messages']));
+            }
+
+            if (isset($parts['ignore-messages'])) {
+                $parts['ignore-messages'] = array_filter(explode("\n", $parts['ignore-messages']));
             }
 
             $keys = ['fixed', 'fixed-encoding', 'fixed-line-endings', 'messages'];
@@ -134,6 +140,7 @@ final class RulesetTests extends TestCase
                 $parts['contents'],
                 $parts['fixed'],
                 $parts['messages'] ?? [],
+                $parts['ignore-messages'] ?? [],
                 $parts['description'] ?? null,
                 $parts['fixed-encoding'] ?? null,
             ];

--- a/tests/cases/classes/one-per-file
+++ b/tests/cases/classes/one-per-file
@@ -19,5 +19,6 @@ class Bar
 
 ---MESSAGES---
 11:1 PSR1.Classes.ClassDeclaration.MultipleClasses
+---IGNORE-MESSAGES---
 11:1 Squiz.Classes.ClassFileName.NoMatch
 ---

--- a/tests/cases/classes/property-visibility
+++ b/tests/cases/classes/property-visibility
@@ -16,5 +16,6 @@ class Foo
 
 ---MESSAGES---
 9:9 PSR2.Classes.PropertyDeclaration.ScopeMissing
+---IGNORE-MESSAGES---
 9:9 PSR2.Classes.PropertyDeclaration.VarUsed
 ---

--- a/tests/cases/interfaces/one-per-file
+++ b/tests/cases/interfaces/one-per-file
@@ -19,5 +19,6 @@ interface Bar
 
 ---MESSAGES---
 11:1 PSR1.Classes.ClassDeclaration.MultipleClasses
+---IGNORE-MESSAGES---
 11:1 Squiz.Classes.ClassFileName.NoMatch
 ---

--- a/tests/cases/trait/one-per-file
+++ b/tests/cases/trait/one-per-file
@@ -19,4 +19,6 @@ trait Bar
 
 ---MESSAGES---
 11:1 PSR1.Classes.ClassDeclaration.MultipleClasses
+---IGNORE-MESSAGES---
+11:1 Squiz.Classes.ClassFileName.NoMatch
 ---

--- a/tests/cases/trait/property-visibility
+++ b/tests/cases/trait/property-visibility
@@ -16,5 +16,6 @@ trait Foo
 
 ---MESSAGES---
 9:9 PSR2.Classes.PropertyDeclaration.ScopeMissing
+---IGNORE-MESSAGES---
 9:9 PSR2.Classes.PropertyDeclaration.VarUsed
 ---


### PR DESCRIPTION
Relates to https://github.com/libero/php-coding-standard/pull/36#discussion_r243189177, https://github.com/libero/php-coding-standard/pull/30#discussion_r230062042, https://github.com/libero/php-coding-standard/pull/24#discussion_r223191443, and probably others.

Allows tests to ignore possible messages that they don't care about.