### PR TITLE
Remove PHP nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 php:
     - 7.2
     - 7.3
-    - nightly
 
 before_install:
     - phpenv config-rm xdebug.ini || true
@@ -40,9 +39,6 @@ stages:
     - Test
     - name: Code Quality
       if: type = pull_request
-
-allow_failures:
-    - php: nightly
 
 cache:
     directories:


### PR DESCRIPTION
Seems to have become PHP 8.

`allow_failures` also seemed not to work. (Only covers `script` not `install`?)