### PR TITLE
Late-static binding must not be used for constants and in final classes

### DIFF
--- a/src/Libero/ruleset.xml
+++ b/src/Libero/ruleset.xml
@@ -34,6 +34,7 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
         <properties>
             <property name="linesCountBeforeFirstContent" value="0"/>

--- a/src/Libero/ruleset.xml
+++ b/src/Libero/ruleset.xml
@@ -29,6 +29,7 @@
             <property name="fixable" value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>

--- a/tests/cases/classes/constant-late-static-binding
+++ b/tests/cases/classes/constant-late-static-binding
@@ -1,0 +1,39 @@
+---DESCRIPTION---
+Late-static binding must not be used for constants
+---FILENAME---
+Foo.php
+---CONTENTS---
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor;
+
+class Foo
+{
+    public const BAR = 'baz';
+
+    public function __construct()
+    {
+        echo static::BAR;
+    }
+}
+
+---FIXED---
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor;
+
+class Foo
+{
+    public const BAR = 'baz';
+
+    public function __construct()
+    {
+        echo self::BAR;
+    }
+}
+
+---

--- a/tests/cases/classes/late-static-binding-constant
+++ b/tests/cases/classes/late-static-binding-constant
@@ -1,0 +1,41 @@
+---DESCRIPTION---
+Late-static binding must not be used for constants
+---FILENAME---
+Foo.php
+---CONTENTS---
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor;
+
+class Foo
+{
+    public function __construct()
+    {
+        static::BAR;
+        static::$baz;
+        static::qux();
+        static::class;
+    }
+}
+
+---FIXED---
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor;
+
+class Foo
+{
+    public function __construct()
+    {
+        self::BAR;
+        static::$baz;
+        static::qux();
+        static::class;
+    }
+}
+
+---

--- a/tests/cases/classes/late-static-binding-useless
+++ b/tests/cases/classes/late-static-binding-useless
@@ -1,5 +1,5 @@
 ---DESCRIPTION---
-Late-static binding must not be used for constants
+Late-static binding must not be used in final classes
 ---FILENAME---
 Foo.php
 ---CONTENTS---
@@ -9,13 +9,13 @@ declare(strict_types=1);
 
 namespace Vendor;
 
-class Foo
+final class Foo
 {
-    public const BAR = 'baz';
-
     public function __construct()
     {
-        echo static::BAR;
+        static::$bar;
+        static::baz();
+        static::class;
     }
 }
 
@@ -26,13 +26,13 @@ declare(strict_types=1);
 
 namespace Vendor;
 
-class Foo
+final class Foo
 {
-    public const BAR = 'baz';
-
     public function __construct()
     {
-        echo self::BAR;
+        self::$bar;
+        self::baz();
+        self::class;
     }
 }
 


### PR DESCRIPTION
(For reasons described in https://github.com/doctrine/coding-standard/pull/112#issue-251565411.)